### PR TITLE
Fix ps7.3 compatibility

### DIFF
--- a/AzureCli.Tests/Invoke-AzureCLi.Objects.Tests.ps1
+++ b/AzureCli.Tests/Invoke-AzureCLi.Objects.Tests.ps1
@@ -8,6 +8,9 @@ Describe "Invoke-AzCli With Object Output" {
 
 	BeforeAll {
 
+		$old_PSNativeCommandArgumentPassing = $PSNativeCommandArgumentPassing
+		$global:PSNativeCommandArgumentPassing = "Windows"
+
 		$jsonText = '{ "IsAz": true }'
 		$convertedObject = [PsCustomObject]@{ IsConvertFromJson = $true }
 		function az {}
@@ -22,6 +25,11 @@ Describe "Invoke-AzCli With Object Output" {
 			$additionalArguments = @{ RemoveParameterValidation =  'Depth' }
 		}
 		Mock ConvertFrom-Json { $convertedObject } @additionalArguments -ModuleName 'AzureCli'
+	}
+
+	AfterAll {
+
+		$global:PSNativeCommandArgumentPassing = $old_PSNativeCommandArgumentPassing
 	}
 
 	It "Returns the parsed data from az" {

--- a/AzureCli.Tests/Invoke-AzureCLi.Objects.Tests.ps1
+++ b/AzureCli.Tests/Invoke-AzureCLi.Objects.Tests.ps1
@@ -8,7 +8,7 @@ Describe "Invoke-AzCli With Object Output" {
 
 	BeforeAll {
 
-		$old_PSNativeCommandArgumentPassing = $PSNativeCommandArgumentPassing
+		$old_PSNativeCommandArgumentPassing = Get-Variable -Name PSNativeCommandArgumentPassing -ValueOnly -ErrorAction SilentlyContinue
 		$global:PSNativeCommandArgumentPassing = "Windows"
 
 		$jsonText = '{ "IsAz": true }'
@@ -29,7 +29,14 @@ Describe "Invoke-AzCli With Object Output" {
 
 	AfterAll {
 
-		$global:PSNativeCommandArgumentPassing = $old_PSNativeCommandArgumentPassing
+		if($old_PSNativeCommandArgumentPassing)
+		{
+			$global:PSNativeCommandArgumentPassing = $old_PSNativeCommandArgumentPassing
+		}
+		else
+		{
+			Clear-Variable PSNativeCommandArgumentPassing -Scope Global
+		}
 	}
 
 	It "Returns the parsed data from az" {

--- a/AzureCli.Tests/Invoke-AzureCLi.Tests.ps1
+++ b/AzureCli.Tests/Invoke-AzureCLi.Tests.ps1
@@ -12,7 +12,7 @@ Describe "Invoke-AzCli general handling" {
 
 		$jsonText = '{ "IsAz": true }'
 
-		$old_PSNativeCommandArgumentPassing = $PSNativeCommandArgumentPassing
+		$old_PSNativeCommandArgumentPassing = Get-Variable -Name PSNativeCommandArgumentPassing -ValueOnly -ErrorAction SilentlyContinue
 
 		$OriginalAzCliVerbosityPreference = Get-Variable -Name AzCliVerbosityPreference -ValueOnly -ErrorAction SilentlyContinue
 
@@ -41,7 +41,14 @@ Describe "Invoke-AzCli general handling" {
 	}
 
 	AfterAll {
-		$global:PSNativeCommandArgumentPassing = $old_PSNativeCommandArgumentPassing
+		if($old_PSNativeCommandArgumentPassing)
+		{
+			$global:PSNativeCommandArgumentPassing = $old_PSNativeCommandArgumentPassing
+		}
+		else
+		{
+			Clear-Variable PSNativeCommandArgumentPassing -Scope Global
+		}
 
 		if ($OriginalAzCliVerbosityPreference)
 		{

--- a/AzureCli.Tests/Invoke-AzureCLi.Text.Tests.ps1
+++ b/AzureCli.Tests/Invoke-AzureCLi.Text.Tests.ps1
@@ -8,6 +8,9 @@ Describe "Invoke-AzCli with commands that produce text" {
 
 	BeforeAll {
 
+		$old_PSNativeCommandArgumentPassing = $PSNativeCommandArgumentPassing
+		$global:PSNativeCommandArgumentPassing = "Windows"
+
 		function az { $args }
 
 		. $PSScriptRoot/Helpers/LoadModule.ps1 -ModuleFolder $ModuleFolder
@@ -20,6 +23,11 @@ Describe "Invoke-AzCli with commands that produce text" {
 			$additionalArguments = @{ RemoveParameterValidation =  'Depth' }
 		}
 		Mock ConvertFrom-Json {} -ModuleName 'AzureCli' @additionalArguments
+	}
+
+	AfterAll {
+		
+		$global:PSNativeCommandArgumentPassing = $old_PSNativeCommandArgumentPassing
 	}
 
 	It "Returns the raw data for no parameters" {

--- a/AzureCli.Tests/Invoke-AzureCLi.Text.Tests.ps1
+++ b/AzureCli.Tests/Invoke-AzureCLi.Text.Tests.ps1
@@ -8,7 +8,7 @@ Describe "Invoke-AzCli with commands that produce text" {
 
 	BeforeAll {
 
-		$old_PSNativeCommandArgumentPassing = $PSNativeCommandArgumentPassing
+		$old_PSNativeCommandArgumentPassing = Get-Variable -Name PSNativeCommandArgumentPassing -ValueOnly -ErrorAction SilentlyContinue
 		$global:PSNativeCommandArgumentPassing = "Windows"
 
 		function az { $args }
@@ -26,8 +26,15 @@ Describe "Invoke-AzCli with commands that produce text" {
 	}
 
 	AfterAll {
-		
-		$global:PSNativeCommandArgumentPassing = $old_PSNativeCommandArgumentPassing
+
+		if($old_PSNativeCommandArgumentPassing)
+		{
+			$global:PSNativeCommandArgumentPassing = $old_PSNativeCommandArgumentPassing
+		}
+		else
+		{
+			Clear-Variable PSNativeCommandArgumentPassing -Scope Global
+		}
 	}
 
 	It "Returns the raw data for no parameters" {

--- a/AzureCli/ArgumentsProcessing/ProcessArguments.ps1
+++ b/AzureCli/ArgumentsProcessing/ProcessArguments.ps1
@@ -24,19 +24,25 @@ function ProcessArguments()
 				$escaped = "$Argument" -replace '(["\\])', '\$0'
 			}
 
-			"Never"
+			default
 			{
 				$escaped = $Argument
 			}
 		}
-		switch($PSNativeCommandArgumentPassing)
+
+		$NativeCommandArgumentPassing = Get-Variable -Name PSNativeCommandArgumentPassing -ValueOnly -ErrorAction SilentlyContinue
+		if(-not $NativeCommandArgumentPassing)
+		{
+			$NativeCommandArgumentPassing = "Legacy"
+		}
+		switch($NativeCommandArgumentPassing)
 		{
 			"Standard"
 			{
-				${escaped}
+				$escaped
 			}
 
-			default  # Not set, Windows or Legacy.
+			default  # Windows or Legacy.
 			{
 				"`"${escaped}`""
 			}

--- a/AzureCli/ArgumentsProcessing/ProcessArguments.ps1
+++ b/AzureCli/ArgumentsProcessing/ProcessArguments.ps1
@@ -29,7 +29,18 @@ function ProcessArguments()
 				$escaped = $Argument
 			}
 		}
-		"`"${escaped}`""
+		switch($PSNativeCommandArgumentPassing)
+		{
+			"Standard"
+			{
+				${escaped}
+			}
+
+			default  # Not set, Windows or Legacy.
+			{
+				"`"${escaped}`""
+			}
+		}
 	}
 
 	$commandLineArguments = @()

--- a/AzureCli/AzureCli.psd1
+++ b/AzureCli/AzureCli.psd1
@@ -28,7 +28,7 @@
 	Description          = 'Cmdlet and alias to make the use of Azure CLI more PowerShell friendly. Process output of Azure CLI from JSON to custom objects.'
 
 	# Minimum version of the PowerShell engine required by this module
-	PowerShellVersion = '6.1.0'
+	PowerShellVersion    = '6.1.0'
 
 	# Name of the PowerShell host required by this module
 	# PowerShellHostName = ''
@@ -115,14 +115,14 @@
 - FIX: MacOS compatibility tag.
 - FEATURE: Support Compatibility with PowerShell 7.3 / $PSNativeCommandArgumentPassing.
   Now checks $PSNativeCommandArgumentPassing and handles accordingly.
-	Backward compatible with original behavior, unless $PSNativeCommandArgumentPassing is set to Standard.
+  Backward compatible with original behavior, unless $PSNativeCommandArgumentPassing is set to Standard.
 
 2.4.0
 
 - Add -ConcatenatedArguments to add arguments in the form `--name=value`. This is mainly required if value starts
   with a - and would otherwise be interpreted as an argument and not a value. For instance '--password "-123"' fails,
   where '--password=-123' succeeds. The values in the hash table of -ConcatenatedArguments parameter will be masked in
-	verbose output if they are of type SecureString.
+  verbose output if they are of type SecureString.
 - Run build and test on Windows, Ubuntu and MacOS.
 - Be honest on support for supported PowerShell versions: Powershell core >= 6.1.0.
 - Correctly mention support for -NoEnumerate: PowerShell core >= 7.0.0.

--- a/AzureCli/AzureCli.psd1
+++ b/AzureCli/AzureCli.psd1
@@ -115,7 +115,7 @@
 - FIX: MacOS compatibility tag.
 - FEATURE: Support Compatibility with PowerShell 7.3 / $PSNativeCommandArgumentPassing.
   Now checks $PSNativeCommandArgumentPassing and handles accordingly.
-
+	Backward compatible with original behavior, unless $PSNativeCommandArgumentPassing is set to Standard.
 
 2.4.0
 

--- a/AzureCli/AzureCli.psd1
+++ b/AzureCli/AzureCli.psd1
@@ -97,7 +97,7 @@
 		PSData = @{
 
 			# Tags applied to this module. These help with module discovery in online galleries.
-			Tags         = 'az', 'cli', 'Azure', 'AzureCli', 'Windows', 'Linux', 'Mac', 'PSEdition_Core'
+			Tags         = 'az', 'cli', 'Azure', 'AzureCli', 'Windows', 'Linux', 'Mac', 'MacOS', 'PSEdition_Core'
 
 			# A URL to the license for this module.
 			LicenseUri   = 'https://raw.githubusercontent.com/dtewinkel/AzureCli/main/AzureCli/license.txt'
@@ -110,6 +110,13 @@
 
 			# ReleaseNotes of this module
 			ReleaseNotes = @'
+2.5.0
+
+- FIX: MacOS compatibility tag.
+- FEATURE: Support Compatibility with PowerShell 7.3 / $PSNativeCommandArgumentPassing.
+  Now checks $PSNativeCommandArgumentPassing and handles accordingly.
+
+
 2.4.0
 
 - Add -ConcatenatedArguments to add arguments in the form `--name=value`. This is mainly required if value starts

--- a/AzureCli/Invoke-AzCli.ps1
+++ b/AzureCli/Invoke-AzCli.ps1
@@ -46,6 +46,9 @@ The commands configure, feedback, and interactive are interactive and do not pro
 By default -Verbose will output verbose information about the command-line used to call Azure CLI. Unless the
 -CliVerbosity is specified this will also result in verbose output from the Azure CLI.
 
+Command-line passing to az CLI is compatible with PowerShell 7.3+ and adheres to $PSNativeCommandArgumentPassing.
+Invoke-AzCli checks $PSNativeCommandArgumentPassing and handles accordingly.
+
 .EXAMPLE
 
 Invoke-AzCli storage account list -Subscription "My Subscription"


### PR DESCRIPTION
- FIX: MacOS compatibility tag.
- FEATURE: Support Compatibility with PowerShell 7.3 / $PSNativeCommandArgumentPassing.
  Now checks $PSNativeCommandArgumentPassing and handles accordingly.
  Backward compatible with original behavior, unless $PSNativeCommandArgumentPassing is set to Standard.